### PR TITLE
Adds docstrings and reorders autodocs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -16,5 +16,5 @@ Pages   = ["index.md"]
 
 ```@autodocs
 Modules = [KMeansClustering]
-Order   = [:function, :type]
+Order   = [:module, :function, :type]
 ```

--- a/src/KMeansClustering.jl
+++ b/src/KMeansClustering.jl
@@ -1,3 +1,14 @@
+
+"""
+    KMeansClustering
+
+A Julia package for clustering algorithms, including K-Means, K-Medoids, K-Means++, BKmeans, and CKmeans.
+
+# Exported Functions
+- [`kmeans`](@ref): Perform K-Means clustering.
+# Usage
+julia> using KMeansClustering
+"""
 module KMeansClustering
 
 using Random
@@ -37,7 +48,7 @@ Available algorithms:
 
 - K-Medoids (method=:kmedoids):
     As described by [E.M. Mirkes, K-means and K-medoids applet. University of Leicester, 2011](http://leicestermath.org.uk/KmeansKmedoids/Kmeans_Kmedoids.html)
-    Unlike typical K-Means, K-Medoids chooses its cluster centers from the given points X instead of calculating 
+    Unlike typical K-Means, K-Medoids chooses its cluster centers from the given points X instead of calculating
     artificial ones.
 
 """


### PR DESCRIPTION
Closes #20

Adds a module-level docstring to provide a high-level overview of the package and its functionalities, including exported functions.

Reorders the autodocs to prioritize modules, then functions, and finally types for better documentation structure.